### PR TITLE
Update party dates to day resolution

### DIFF
--- a/data/csvw-metadata.json
+++ b/data/csvw-metadata.json
@@ -294,22 +294,20 @@
           {
             "name": "inception",
             "titles": "inception",
-            "dc:description": "Party inception date. Values may use a nominal full date even when precision is year-level.",
+            "dc:description": "Party inception date, where known. Values may use a nominal full date even when precision is year-level.",
             "datatype": {
               "base": "date",
               "format": "yyyy-MM-dd"
-            },
-            "required": true
+            }
           },
           {
             "name": "inception_precision",
             "titles": "inception_precision",
-            "dc:description": "Precision of the inception date.",
+            "dc:description": "Precision of the inception date, where known.",
             "datatype": {
               "base": "string",
               "format": "^(day|year)$"
-            },
-            "required": true
+            }
           },
           {
             "name": "dissolution",

--- a/data/party.csv
+++ b/data/party.csv
@@ -1,20 +1,20 @@
 party_id,party,inception,inception_precision,dissolution,dissolution_precision,successor_id,swerik_party_id,swerik_successor
 Q105112,Socialdemokraterna,1889-01-01,year,,,Q10672903,i-VS8ddgxigwL5TceKtXGApS,i-SwzbNNYoyZYULLDiTu2zGP
-Q111033682,Högerpartiet,1952-01-01,year,1969-01-01,day,Q110843,i-3A4u29WVtvfu8i1KwuPEeE,i-F6Stwe8wVnSPa3BbgusszQ
-Q110843,Moderata samlingspartiet,1969-01-01,year,,,,i-F6Stwe8wVnSPa3BbgusszQ,
-Q110472693,Bondeförbundet,1913-01-01,year,1956-12-31,year,Q110832,i-CNbGLyuzdkRJ2sJBBpzJit,i-UiFZiVNo3YgVfyN93Qigiv
-Q110832,Centerpartiet,1957-01-01,year,,,,i-UiFZiVNo3YgVfyN93Qigiv,
-Q4887122,Frisinnade folkpartiet,1924-01-01,year,1935-01-01,year,Q110857,i-V7MTfG5XaAmjbSDtLkyyfc,i-Hm85EQfFmbYuYFPjpXtuCj
-Q110857,Folkpartiet liberalerna,1990-01-01,year,2015-11-25,day,Q110857,i-Hm85EQfFmbYuYFPjpXtuCj,i-Kpkv9BSujEEJp1S4rDiDt7|i-FpGjUCojANuvvwqsNXjcuu
-Q110857,Liberalerna,2015-11-25,day,,,,i-Kpkv9BSujEEJp1S4rDiDt7,
+Q111033682,Högerpartiet,1952-07-17,day,1969-01-09,day,Q110843,i-3A4u29WVtvfu8i1KwuPEeE,i-F6Stwe8wVnSPa3BbgusszQ
+Q110843,Moderata samlingspartiet,1969-01-10,day,,,,i-F6Stwe8wVnSPa3BbgusszQ,
+Q110472693,Bondeförbundet,1913-01-01,year,1957-07-02,day,Q110832,i-CNbGLyuzdkRJ2sJBBpzJit,i-UiFZiVNo3YgVfyN93Qigiv
+Q110832,Centerpartiet,1957-07-03,day,,,,i-UiFZiVNo3YgVfyN93Qigiv,
+Q4887122,Frisinnade folkpartiet,1923-06-06,day,1934-08-05,day,Q110857,i-V7MTfG5XaAmjbSDtLkyyfc,i-FpGjUCojANuvvwqsNXjcuu
+Q110857,Folkpartiet liberalerna,1990-11-24,day,2015-11-22,day,Q110857,i-Hm85EQfFmbYuYFPjpXtuCj,i-Kpkv9BSujEEJp1S4rDiDt7|i-FpGjUCojANuvvwqsNXjcuu
+Q110857,Liberalerna,2015-11-23,day,,,,i-Kpkv9BSujEEJp1S4rDiDt7,
 Q504069,Sverigedemokraterna,1988-02-06,day,,,,i-Cb6hYmJf4EDxesFRgErquJ,
 Q213451,Miljöpartiet,1981-09-20,day,,,,i-Qha9NerKBigcjJXgoRk4Md,
-Q111285801,Sveriges kommunistiska parti,1921-01-01,year,1967-01-01,year,Q1787940,i-TQCUzfkvYhBFrXeQwXoENH,i-2SVXJYpXaRHXxbWRcbRd5N
-Q110837,Vänsterpartiet Kommunisterna,1967-01-01,year,1990-01-01,year,Q110837,i-2SVXJYpXaRHXxbWRcbRd5N,i-CJb7bcc1eZcehvGarg8GpB
-Q110837,Vänsterpartiet,1990-01-01,year,,,,i-CJb7bcc1eZcehvGarg8GpB,
-Q213654,Kristdemokratiska Samhällspartiet,1987-01-01,year,1996-01-01,year,Q213654,i-B79rKJX4ZV61ozevGt8JLL,i-BRRSButj7zSqB1u7zD6hod
-Q213654,Kristdemokraterna,1996-01-01,year,,,,i-BRRSButj7zSqB1u7zD6hod,
-Q967278,Ny demokrati,1991-01-01,year,2000-02-25,day,,i-YYGgpk3VEG9XW1wZTzUShT,
+Q111285801,Sveriges kommunistiska parti,1921-03-28,day,1967-05-15,day,Q1787940,i-TQCUzfkvYhBFrXeQwXoENH,i-2SVXJYpXaRHXxbWRcbRd5N
+Q110837,Vänsterpartiet Kommunisterna,1967-05-16,day,1990-05-26,day,Q110837,i-2SVXJYpXaRHXxbWRcbRd5N,i-CJb7bcc1eZcehvGarg8GpB
+Q110837,Vänsterpartiet,1990-05-27,day,,,,i-CJb7bcc1eZcehvGarg8GpB,
+Q213654,Kristdemokratiska Samhällspartiet,1964-03-20,day,1996-06-28,day,Q213654,i-B79rKJX4ZV61ozevGt8JLL,i-BRRSButj7zSqB1u7zD6hod
+Q213654,Kristdemokraterna,1996-06-29,day,,,,i-BRRSButj7zSqB1u7zD6hod,
+Q967278,Ny demokrati,1991-02-04,day,2000-02-25,day,,i-YYGgpk3VEG9XW1wZTzUShT,
 Q10554125,Lantmanna- och borgarepartiet inom andrakammaren,1912-01-01,year,1935-01-01,year,Q111077860,i-NhgK2ujGF5t35o2VjT8Q5U,i-4nyjRorziqEDtDmp1ZXDoP
 Q111077860,Högerns riksdagsgrupp,1935-01-01,year,1970-01-01,year,Q110843,i-4nyjRorziqEDtDmp1ZXDoP,i-F6Stwe8wVnSPa3BbgusszQ
 Q3480145,Första kammarens nationella parti,1912-01-01,year,1935-01-01,year,Q111077860,i-3kDgsboJBSv4zGqF4zfCsY,i-4nyjRorziqEDtDmp1ZXDoP
@@ -53,9 +53,11 @@ Q10594830,Nationella framstegspartiet,1906-01-01,year,1912-01-01,year,Q10554125,
 Q10499214,Frisinnade försvarsvänner,1914-01-01,year,1914-12-31,year,,i-GM695yHGsRXSAorwcFL7x5,
 Q10672903,Socialdemokratiska vänstergruppen,1917-01-01,year,1924-01-01,year,Q105112|Q111285801,i-SwzbNNYoyZYULLDiTu2zGP,i-VS8ddgxigwL5TceKtXGApS|i-TQCUzfkvYhBFrXeQwXoENH
 Q10540831,Jordbrukarnas fria grupp,1918-01-01,year,1922-01-01,year,Q110472693,i-PvAXgvY3G8qXv1ZM9xudRA,i-CNbGLyuzdkRJ2sJBBpzJit
-Q10560990,Liberala riksdagspartiet,1924-01-01,year,1935-01-01,year,Q110857,i-9fghptqkyNzTVdA8knRCGq,i-Kpkv9BSujEEJp1S4rDiDt7|i-FpGjUCojANuvvwqsNXjcuu
-Q111188360,Kilbomspartiet,1924-01-01,year,1934-01-01,year,Q2425638,i-VzZnBZoi4EChaiCfF6kxbz,i-SeXPXWPfyJxdeuuFtkdhxh
-Q2425638,Socialistiska partiet,1934-01-01,year,1944-01-01,year,,i-SeXPXWPfyJxdeuuFtkdhxh,
+Q10560990,Liberala riksdagspartiet,1923-10-07,day,1934-08-05,day,Q110857,i-9fghptqkyNzTVdA8knRCGq,i-FpGjUCojANuvvwqsNXjcuu
+Q111188360,Kilbomspartiet,1929-10-09,day,1934-04-30,day,Q2425638,i-VzZnBZoi4EChaiCfF6kxbz,i-SeXPXWPfyJxdeuuFtkdhxh
+Q2425638,Socialistiska partiet,1934-05-01,day,1944-01-01,year,,i-SeXPXWPfyJxdeuuFtkdhxh,
 Q10579102,Medborgerlig samling (1964–1968),1964-01-01,year,1968-01-01,year,,i-ANbQF76SzeSESXQFvzPzFw,
-Q110857,Folkpartiet,1934-01-01,year,1990-01-01,year,Q110857,i-FpGjUCojANuvvwqsNXjcuu,i-Hm85EQfFmbYuYFPjpXtuCj
+Q110857,Folkpartiet,1934-08-05,day,1990-11-23,day,Q110857,i-FpGjUCojANuvvwqsNXjcuu,i-Hm85EQfFmbYuYFPjpXtuCj
 ,Utan partibeteckning,,,,,,i-851f4cdfa36f4dbab4b24855a1eb43ce,
+,Högerns riksorganisation,1938-06-18,day,1952-07-16,day,,i-HNe8KkGHn59Q6R8HE40hvQ,i-3A4u29WVtvfu8i1KwuPEeE
+,Frisinnade landsföreningen,,,1934-08-05,day,,i-6phCStV52pp0GuBufmEi9g,i-FpGjUCojANuvvwqsNXjcuu


### PR DESCRIPTION
This PR comes from scraping Dagens Nyheter for name changes from 1925 onwards.
When the dates have prefix like `≤` it means the DN-article does not mention an exact date so I've used the day before the publication day.

The csvw schema was changed since some of the parties does not have a known inception date.

Some renames like Bondeförbundet → Landsbygdspartiet Bondeförbundet in 1943 was skipped since I had to create a new party for it. I can do it if you think that is a better idea.

## Socialdemokraterna

Inga namnbyten funna i DN 1925–2026.

## Högern / Moderaterna

* 1938-06-18 — Allmänna valmansförbundet → Högerns riksorganisation (riksstämma, Jönköping) [[DN 1938-06-19](https://arkivet.dn.se/tidning/1938-06-19/163/15)](https://arkivet.dn.se/tidning/1938-06-19/163/15)
* 1952-07-16 (≤) — Partibeteckningen ”Högerpartiet” registreras hos regeringen (ansökan; inget stämmobeslut funnet i DN) [[DN 1952-07-17](https://arkivet.dn.se/tidning/1952-07-17/11161-191/5)](https://arkivet.dn.se/tidning/1952-07-17/11161-191/5)
* 1969-01-09 — Högerpartiet → Moderata samlingspartiet (partistämma, 154–51) [[DN 1969-01-10](https://arkivet.dn.se/tidning/1969-01-10/11171-8/6)](https://arkivet.dn.se/tidning/1969-01-10/11171-8/6)

## Bondeförbundet / Centerpartiet

* 1943-06-15 — Bondeförbundet → Landsbygdspartiet Bondeförbundet (riksstämma, Västerås, enhälligt) [[DN 1943-06-16](https://arkivet.dn.se/tidning/1943-06-16/160/11)](https://arkivet.dn.se/tidning/1943-06-16/160/11)
* 1957-07-02 — Landsbygdspartiet Bondeförbundet → Centerpartiet Bondeförbundet (partistämma, Karlstad, 2/3-majoritet) [[DN 1957-07-03](https://arkivet.dn.se/tidning/1957-07-03/11164-177/1)](https://arkivet.dn.se/tidning/1957-07-03/11164-177/1)
* (odaterat) — Centerpartiet Bondeförbundet → Centerpartiet: formellt beslut ej funnet i DN [[DN 1958-04-21](https://arkivet.dn.se/tidning/1958-04-21/11165-107/11)](https://arkivet.dn.se/tidning/1958-04-21/11165-107/11)

## Liberalerna (Frisinnade folkpartiet / Sveriges liberala parti / Folkpartiet)

* 1923-06-06 (≤) — Frisinnade utbrytargruppen antar namnet Frisinnade folkpartiet efter Liberala samlingspartiets sprängning [[DN 1923-06-07](https://arkivet.dn.se/tidning/1923-06-07/11160-151/4)](https://arkivet.dn.se/tidning/1923-06-07/11160-151/4)
* 1923-10-07 — Sveriges liberala parti bildas (den liberala flygeln) [[DN 1923-10-23](https://arkivet.dn.se/tidning/1923-10-23/11160-287/9)](https://arkivet.dn.se/tidning/1923-10-23/11160-287/9)
* 1934-08-05 — Frisinnade folkpartiet + Sveriges liberala parti → Folkpartiet (konstituerande möte) [[DN 1934-08-06](https://arkivet.dn.se/tidning/1934-08-06/210/1)](https://arkivet.dn.se/tidning/1934-08-06/210/1)
* 1990-11-23 — Folkpartiet → Folkpartiet liberalerna (landsmötesbeslut) [[DN 1990-11-24](https://arkivet.dn.se/tidning/1990-11-24/319/6)](https://arkivet.dn.se/tidning/1990-11-24/319/6)
* 2015-11-22 — Folkpartiet liberalerna → Liberalerna (landsmöte, Stockholm, söndag) [[DN 2015-11-23](https://arkivet.dn.se/tidning/2015-11-23/134593-318/10)](https://arkivet.dn.se/tidning/2015-11-23/134593-318/10)

## SKP / VPK / Vänsterpartiet

* 1921-03-27/28 — Sverges socialdemokratiska vänsterparti → Sverges kommunistiska parti (kongressbeslut, påsken) [[DN 1921-03-29](https://arkivet.dn.se/tidning/1921-03-29/82/9)](https://arkivet.dn.se/tidning/1921-03-29/82/9)
* 1967-05-15 — SKP → Vänsterpartiet kommunisterna (21:a kongressen, beslut måndag kväll) [[DN 1967-05-16](https://arkivet.dn.se/tidning/1967-05-16/11171-129/1)](https://arkivet.dn.se/tidning/1967-05-16/11171-129/1)
* 1990-05-26 (≤) — VPK → Vänsterpartiet (29:e kongressen) [[DN 1990-05-27](https://arkivet.dn.se/tidning/1990-05-27/141/8)](https://arkivet.dn.se/tidning/1990-05-27/141/8)

## KDS / Kristdemokraterna

* 1964-03-20 — Kristen demokratisk samling (KDS) bildas (Stockholm) [[DN 1964-03-21](https://arkivet.dn.se/tidning/1964-03-21/79/1)](https://arkivet.dn.se/tidning/1964-03-21/79/1)
* 1987-06-26 — KDS → Kristdemokratiska samhällspartiet (riksting, Eskilstuna; förkortningen kds behålls) [[DN 1987-06-27](https://arkivet.dn.se/tidning/1987-06-27/173/8)](https://arkivet.dn.se/tidning/1987-06-27/173/8)
* 1996-06-28 — Kristdemokratiska samhällspartiet → Kristdemokraterna (kd) (riksting, Örnsköldsvik) [[DN 1996-06-29](https://arkivet.dn.se/tidning/1996-06-29/11175-174/8)](https://arkivet.dn.se/tidning/1996-06-29/11175-174/8)

## Miljöpartiet

* 1981-09-19/20 — Miljöpartiet bildas; namn och maskrossymbol fastställs (grundningskongress, Örebro) [[DN 1981-09-21](https://arkivet.dn.se/tidning/1981-09-21/256/2)](https://arkivet.dn.se/tidning/1981-09-21/256/2)
* 1985-01-04/06 — Miljöpartiet → Miljöpartiet de gröna (extra kongress, trettonhelgen) [[DN 1985-01-07](https://arkivet.dn.se/tidning/1985-01-07/6/8)](https://arkivet.dn.se/tidning/1985-01-07/6/8)

## Sverigedemokraterna

* 1988-02-06 — Sverigedemokraterna bildas (ingen DN-täckning av grundandet — första DN-omnämnande 1988-08-17) [[DN 1988-08-17](https://arkivet.dn.se/tidning/1988-08-17/222/21)](https://arkivet.dn.se/tidning/1988-08-17/222/21)

Inga namnbyten 1988–2026 (DN-verifierat).

## Ny demokrati

* 1991-02-04 — Ny demokrati bildas (presskonferens; Karlsson & Wachtmeister) [[DN 1991-02-05](https://arkivet.dn.se/tidning/1991-02-05/35/1)](https://arkivet.dn.se/tidning/1991-02-05/35/1)
* 2000-02-25 — Ny demokrati försätts i konkurs (Lidköpings tingsrätt) [[DN 2000-03-02 (kungörelse)](https://arkivet.dn.se/tidning/2000-03-02/11184-61/25)](https://arkivet.dn.se/tidning/2000-03-02/11184-61/25)

Inga namnbyten 1991–2000 (DN-verifierat).