### PR TITLE
Add partly leaders csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ The `data/` directory contains a number of csv files in Normal form where the `p
 - party
 - party_id
 
+### `data/party_leaders.csv`
+- person_id
+- name
+- start_date
+- end_date
+- party_id
+
 ### `data/person.csv`
 - person_id
 - born

--- a/data/csvw-metadata.json
+++ b/data/csvw-metadata.json
@@ -351,6 +351,70 @@
       }
     },
     {
+      "url": "party_leaders.csv",
+      "dc:title": "Party Leaders",
+      "dc:description": "Party leaders over time, each period resolved to the SWERIK party record that existed during it. A tenure spanning a party name change is split into one row per party period, and coexisting party records (a parliamentary group alongside the party organisation) each get their own row, so rows are not mutually exclusive.",
+      "tableSchema": {
+        "columns": [
+          {
+            "name": "person_id",
+            "titles": "person_id",
+            "dc:description": "Stable SWERIK person identifier. Empty where the leader has no person record in the corpus.",
+            "datatype": "string"
+          },
+          {
+            "name": "name",
+            "titles": "name",
+            "dc:description": "Leader name as given in the source, retained so that rows without a person_id remain identifiable.",
+            "datatype": "string",
+            "required": true
+          },
+          {
+            "name": "start_date",
+            "titles": "start_date",
+            "dc:description": "Start of the leadership period, clipped to the party's inception where the tenure began before it. Values may be full dates, year-month dates or year-level dates depending on source precision.",
+            "datatype": {
+              "base": "string",
+              "format": "^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$"
+            },
+            "required": true
+          },
+          {
+            "name": "end_date",
+            "titles": "end_date",
+            "dc:description": "End of the leadership period, clipped to the party's dissolution where the tenure outlasted it. Empty where the period is ongoing or its end is unknown. Values may be full dates, year-month dates or year-level dates depending on source precision.",
+            "datatype": {
+              "base": "string",
+              "format": "^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$"
+            }
+          },
+          {
+            "name": "party_id",
+            "titles": "party_id",
+            "dc:description": "Stable SWERIK party identifier of the party led during this period. Note that this column holds a SWERIK party identifier, unlike the party_id column of party.csv and party_affiliation.csv, which holds an external Wikidata QID.",
+            "datatype": "string",
+            "required": true
+          }
+        ],
+        "foreignKeys": [
+          {
+            "columnReference": "person_id",
+            "reference": {
+              "resource": "person.csv",
+              "columnReference": "person_id"
+            }
+          },
+          {
+            "columnReference": "party_id",
+            "reference": {
+              "resource": "party.csv",
+              "columnReference": "swerik_party_id"
+            }
+          }
+        ]
+      }
+    },
+    {
       "url": "minister.csv",
       "dc:title": "Ministers",
       "dc:description": "Ministerial appointments linked to persons.",

--- a/data/csvw-metadata.json
+++ b/data/csvw-metadata.json
@@ -294,22 +294,20 @@
           {
             "name": "inception",
             "titles": "inception",
-            "dc:description": "Party inception date. Values may use a nominal full date even when precision is year-level.",
+            "dc:description": "Party inception date, where known. Values may use a nominal full date even when precision is year-level.",
             "datatype": {
               "base": "date",
               "format": "yyyy-MM-dd"
-            },
-            "required": true
+            }
           },
           {
             "name": "inception_precision",
             "titles": "inception_precision",
-            "dc:description": "Precision of the inception date.",
+            "dc:description": "Precision of the inception date, where known.",
             "datatype": {
               "base": "string",
               "format": "^(day|year)$"
-            },
-            "required": true
+            }
           },
           {
             "name": "dissolution",

--- a/data/party.csv
+++ b/data/party.csv
@@ -1,20 +1,20 @@
 party_id,party,inception,inception_precision,dissolution,dissolution_precision,successor_id,swerik_party_id,swerik_successor
 Q105112,Socialdemokraterna,1889-01-01,year,,,Q10672903,i-VS8ddgxigwL5TceKtXGApS,i-SwzbNNYoyZYULLDiTu2zGP
-Q111033682,Högerpartiet,1952-01-01,year,1969-01-01,day,Q110843,i-3A4u29WVtvfu8i1KwuPEeE,i-F6Stwe8wVnSPa3BbgusszQ
-Q110843,Moderata samlingspartiet,1969-01-01,year,,,,i-F6Stwe8wVnSPa3BbgusszQ,
-Q110472693,Bondeförbundet,1913-01-01,year,1956-12-31,year,Q110832,i-CNbGLyuzdkRJ2sJBBpzJit,i-UiFZiVNo3YgVfyN93Qigiv
-Q110832,Centerpartiet,1957-01-01,year,,,,i-UiFZiVNo3YgVfyN93Qigiv,
-Q4887122,Frisinnade folkpartiet,1924-01-01,year,1935-01-01,year,Q110857,i-V7MTfG5XaAmjbSDtLkyyfc,i-Hm85EQfFmbYuYFPjpXtuCj
-Q110857,Folkpartiet liberalerna,1990-01-01,year,2015-11-25,day,Q110857,i-Hm85EQfFmbYuYFPjpXtuCj,i-Kpkv9BSujEEJp1S4rDiDt7|i-FpGjUCojANuvvwqsNXjcuu
-Q110857,Liberalerna,2015-11-25,day,,,,i-Kpkv9BSujEEJp1S4rDiDt7,
+Q111033682,Högerpartiet,1952-07-17,day,1969-01-09,day,Q110843,i-3A4u29WVtvfu8i1KwuPEeE,i-F6Stwe8wVnSPa3BbgusszQ
+Q110843,Moderata samlingspartiet,1969-01-10,day,,,,i-F6Stwe8wVnSPa3BbgusszQ,
+Q110472693,Bondeförbundet,1913-01-01,year,1957-07-02,day,Q110832,i-CNbGLyuzdkRJ2sJBBpzJit,i-UiFZiVNo3YgVfyN93Qigiv
+Q110832,Centerpartiet,1957-07-03,day,,,,i-UiFZiVNo3YgVfyN93Qigiv,
+Q4887122,Frisinnade folkpartiet,1923-06-06,day,1934-08-05,day,Q110857,i-V7MTfG5XaAmjbSDtLkyyfc,i-FpGjUCojANuvvwqsNXjcuu
+Q110857,Folkpartiet liberalerna,1990-11-24,day,2015-11-22,day,Q110857,i-Hm85EQfFmbYuYFPjpXtuCj,i-Kpkv9BSujEEJp1S4rDiDt7|i-FpGjUCojANuvvwqsNXjcuu
+Q110857,Liberalerna,2015-11-23,day,,,,i-Kpkv9BSujEEJp1S4rDiDt7,
 Q504069,Sverigedemokraterna,1988-02-06,day,,,,i-Cb6hYmJf4EDxesFRgErquJ,
 Q213451,Miljöpartiet,1981-09-20,day,,,,i-Qha9NerKBigcjJXgoRk4Md,
-Q111285801,Sveriges kommunistiska parti,1921-01-01,year,1967-01-01,year,Q1787940,i-TQCUzfkvYhBFrXeQwXoENH,i-2SVXJYpXaRHXxbWRcbRd5N
-Q110837,Vänsterpartiet Kommunisterna,1967-01-01,year,1990-01-01,year,Q110837,i-2SVXJYpXaRHXxbWRcbRd5N,i-CJb7bcc1eZcehvGarg8GpB
-Q110837,Vänsterpartiet,1990-01-01,year,,,,i-CJb7bcc1eZcehvGarg8GpB,
-Q213654,Kristdemokratiska Samhällspartiet,1987-01-01,year,1996-01-01,year,Q213654,i-B79rKJX4ZV61ozevGt8JLL,i-BRRSButj7zSqB1u7zD6hod
-Q213654,Kristdemokraterna,1996-01-01,year,,,,i-BRRSButj7zSqB1u7zD6hod,
-Q967278,Ny demokrati,1991-01-01,year,2000-02-25,day,,i-YYGgpk3VEG9XW1wZTzUShT,
+Q111285801,Sveriges kommunistiska parti,1921-03-28,day,1967-05-15,day,Q1787940,i-TQCUzfkvYhBFrXeQwXoENH,i-2SVXJYpXaRHXxbWRcbRd5N
+Q110837,Vänsterpartiet Kommunisterna,1967-05-16,day,1990-05-26,day,Q110837,i-2SVXJYpXaRHXxbWRcbRd5N,i-CJb7bcc1eZcehvGarg8GpB
+Q110837,Vänsterpartiet,1990-05-27,day,,,,i-CJb7bcc1eZcehvGarg8GpB,
+Q213654,Kristdemokratiska Samhällspartiet,1964-03-20,day,1996-06-28,day,Q213654,i-B79rKJX4ZV61ozevGt8JLL,i-BRRSButj7zSqB1u7zD6hod
+Q213654,Kristdemokraterna,1996-06-29,day,,,,i-BRRSButj7zSqB1u7zD6hod,
+Q967278,Ny demokrati,1991-02-04,day,2000-02-25,day,,i-YYGgpk3VEG9XW1wZTzUShT,
 Q10554125,Lantmanna- och borgarepartiet inom andrakammaren,1912-01-01,year,1935-01-01,year,Q111077860,i-NhgK2ujGF5t35o2VjT8Q5U,i-4nyjRorziqEDtDmp1ZXDoP
 Q111077860,Högerns riksdagsgrupp,1935-01-01,year,1970-01-01,year,Q110843,i-4nyjRorziqEDtDmp1ZXDoP,i-F6Stwe8wVnSPa3BbgusszQ
 Q3480145,Första kammarens nationella parti,1912-01-01,year,1935-01-01,year,Q111077860,i-3kDgsboJBSv4zGqF4zfCsY,i-4nyjRorziqEDtDmp1ZXDoP
@@ -53,9 +53,11 @@ Q10594830,Nationella framstegspartiet,1906-01-01,year,1912-01-01,year,Q10554125,
 Q10499214,Frisinnade försvarsvänner,1914-01-01,year,1914-12-31,year,,i-GM695yHGsRXSAorwcFL7x5,
 Q10672903,Socialdemokratiska vänstergruppen,1917-01-01,year,1924-01-01,year,Q105112|Q111285801,i-SwzbNNYoyZYULLDiTu2zGP,i-VS8ddgxigwL5TceKtXGApS|i-TQCUzfkvYhBFrXeQwXoENH
 Q10540831,Jordbrukarnas fria grupp,1918-01-01,year,1922-01-01,year,Q110472693,i-PvAXgvY3G8qXv1ZM9xudRA,i-CNbGLyuzdkRJ2sJBBpzJit
-Q10560990,Liberala riksdagspartiet,1924-01-01,year,1935-01-01,year,Q110857,i-9fghptqkyNzTVdA8knRCGq,i-Kpkv9BSujEEJp1S4rDiDt7|i-FpGjUCojANuvvwqsNXjcuu
-Q111188360,Kilbomspartiet,1924-01-01,year,1934-01-01,year,Q2425638,i-VzZnBZoi4EChaiCfF6kxbz,i-SeXPXWPfyJxdeuuFtkdhxh
-Q2425638,Socialistiska partiet,1934-01-01,year,1944-01-01,year,,i-SeXPXWPfyJxdeuuFtkdhxh,
+Q10560990,Liberala riksdagspartiet,1923-10-07,day,1934-08-05,day,Q110857,i-9fghptqkyNzTVdA8knRCGq,i-FpGjUCojANuvvwqsNXjcuu
+Q111188360,Kilbomspartiet,1929-10-09,day,1934-04-30,day,Q2425638,i-VzZnBZoi4EChaiCfF6kxbz,i-SeXPXWPfyJxdeuuFtkdhxh
+Q2425638,Socialistiska partiet,1934-05-01,day,1944-01-01,year,,i-SeXPXWPfyJxdeuuFtkdhxh,
 Q10579102,Medborgerlig samling (1964–1968),1964-01-01,year,1968-01-01,year,,i-ANbQF76SzeSESXQFvzPzFw,
-Q110857,Folkpartiet,1934-01-01,year,1990-01-01,year,Q110857,i-FpGjUCojANuvvwqsNXjcuu,i-Hm85EQfFmbYuYFPjpXtuCj
+Q110857,Folkpartiet,1934-08-05,day,1990-11-23,day,Q110857,i-FpGjUCojANuvvwqsNXjcuu,i-Hm85EQfFmbYuYFPjpXtuCj
 ,Utan partibeteckning,,,,,,i-851f4cdfa36f4dbab4b24855a1eb43ce,
+,Högerns riksorganisation,1938-06-18,day,1952-07-16,day,,i-HNe8KkGHn59Q6R8HE40hvQ,i-3A4u29WVtvfu8i1KwuPEeE
+,Frisinnade landsföreningen,,,1934-08-05,day,,i-6phCStV52pp0GuBufmEi9g,i-FpGjUCojANuvvwqsNXjcuu

--- a/data/party_leaders.csv
+++ b/data/party_leaders.csv
@@ -1,0 +1,165 @@
+person_id,name,start_date,end_date,party_id
+,Claes Tholin,1896-02,1907-01-17,i-VS8ddgxigwL5TceKtXGApS
+i-VM3kn4h4mTkLoFpEyrhy5t,Hjalmar Branting,1907-01-17,1925-02-24,i-VS8ddgxigwL5TceKtXGApS
+i-L7nvZ56RferP78KNpz2Uh1,Per Albin Hansson,1925-11-15,1946-10-06,i-VS8ddgxigwL5TceKtXGApS
+i-4Mr7D9BCozgkT5mSiFk6Gv,Gustav Möller,1946-10-07,1946-10-09,i-VS8ddgxigwL5TceKtXGApS
+i-8fp2gLHtWqnYwFqeVLu5w8,Tage Erlander,1946-10-09,1969-10-01,i-VS8ddgxigwL5TceKtXGApS
+i-DKX1MP4aaNtFZSpMKXCwY,Olof Palme,1969-10-01,1986-02-28,i-VS8ddgxigwL5TceKtXGApS
+i-WYkrZExE7jfwHjmfH1DPwg,Ingvar Carlsson,1986-03-01,1996-03-15,i-VS8ddgxigwL5TceKtXGApS
+i-3kVCtR7mCK6mW2F6oaBMR5,Göran Persson,1996-03-15,2007-03-17,i-VS8ddgxigwL5TceKtXGApS
+i-GFJcxAB9fyzG2VN1HakscJ,Mona Sahlin,2007-03-17,2011-03-25,i-VS8ddgxigwL5TceKtXGApS
+i-UojdP4mF9dqkxf3QQ9oPFe,Håkan Juholt,2011-03-25,2012-01-21,i-VS8ddgxigwL5TceKtXGApS
+i-Xzt52E3ZeNyJ9HLW4B5Sk1,Stefan Löfven,2012-01-27,2021-11-04,i-VS8ddgxigwL5TceKtXGApS
+i-74hLepsvAgUMEvVVtBCGuc,Magdalena Andersson,2021-11-04,,i-VS8ddgxigwL5TceKtXGApS
+i-QfeDyZ27DQmH17bsjAZDYK,Gustaf Fredrik Östberg,1905,1905,i-9gKkoAVdC2bU1LFrXNHCxd
+i-5p2XzfXQYwvKFEXTR5iFUy,Hugo Tamm,1907,1907-10-04,i-9gKkoAVdC2bU1LFrXNHCxd
+i-QfeDyZ27DQmH17bsjAZDYK,Gustaf Fredrik Östberg,1908,1912,i-9gKkoAVdC2bU1LFrXNHCxd
+i-QfeDyZ27DQmH17bsjAZDYK,Gustaf Fredrik Östberg,1910,1912,i-W4wDukSDpMNcSwPExagVMB
+i-QfeDyZ27DQmH17bsjAZDYK,Gustaf Fredrik Östberg,1912,1912,i-3kDgsboJBSv4zGqF4zfCsY
+i-Fnu186BGHvvTJDuB7t6zMb,Arvid Lindman,1912,1912,i-9gKkoAVdC2bU1LFrXNHCxd
+i-Fnu186BGHvvTJDuB7t6zMb,Arvid Lindman,1912,1912,i-W4wDukSDpMNcSwPExagVMB
+i-Fnu186BGHvvTJDuB7t6zMb,Arvid Lindman,1912,1917,i-3kDgsboJBSv4zGqF4zfCsY
+i-WFAgacpHQWjHhsNNuUmKTE,Olof Jonsson i Hov,1917,1917,i-3kDgsboJBSv4zGqF4zfCsY
+i-Fnu186BGHvvTJDuB7t6zMb,Arvid Lindman,1919,1920,i-3kDgsboJBSv4zGqF4zfCsY
+i-7qWGCczgXmCbLWUggUPPsa,Carl Hallendorff,1922,1922,i-3kDgsboJBSv4zGqF4zfCsY
+i-Fnu186BGHvvTJDuB7t6zMb,Arvid Lindman,1924,1935-06-03,i-3kDgsboJBSv4zGqF4zfCsY
+i-Fnu186BGHvvTJDuB7t6zMb,Arvid Lindman,1935,1935-06-03,i-4nyjRorziqEDtDmp1ZXDoP
+i-CU4eSFiFKKx8yk9jS92iFV,Gösta Bagge,1935-06-03,1944-12-09,i-4nyjRorziqEDtDmp1ZXDoP
+i-PRkToj2ss6C9sjWtUtqNNh,Fritiof Domö,1944-12-09,1950-01-09,i-4nyjRorziqEDtDmp1ZXDoP
+i-2gvrXtH5sAT9PgXsCVpQSW,Jarl Hjalmarson,1950-01-09,1961-08-28,i-4nyjRorziqEDtDmp1ZXDoP
+i-2gvrXtH5sAT9PgXsCVpQSW,Jarl Hjalmarson,1952-07-17,1961-08-28,i-3A4u29WVtvfu8i1KwuPEeE
+i-S8m3fmgdhJmz5CbDpVBctA,Gunnar Heckscher,1961-08-28,1965-06-01,i-4nyjRorziqEDtDmp1ZXDoP
+i-S8m3fmgdhJmz5CbDpVBctA,Gunnar Heckscher,1961-08-28,1965-06-01,i-3A4u29WVtvfu8i1KwuPEeE
+i-MTA6YhhXtmnmGGwd2tXXRL,Yngve Holmberg,1965-06-01,1970-11-14,i-4nyjRorziqEDtDmp1ZXDoP
+i-MTA6YhhXtmnmGGwd2tXXRL,Yngve Holmberg,1965-06-01,1969-01-09,i-3A4u29WVtvfu8i1KwuPEeE
+i-MTA6YhhXtmnmGGwd2tXXRL,Yngve Holmberg,1969-01-10,1970-11-14,i-F6Stwe8wVnSPa3BbgusszQ
+i-LQKP5CDY62YpFZWUbs7QiW,Gösta Bohman,1970-11-14,1981-10-25,i-F6Stwe8wVnSPa3BbgusszQ
+i-Pe1ftVDt68xexZMLUFEKsL,Ulf Adelsohn,1981-10-25,1986-08-23,i-F6Stwe8wVnSPa3BbgusszQ
+i-AZnaWEAg22YQ3HzVMfNSHR,Carl Bildt,1986-08-23,1999-09-04,i-F6Stwe8wVnSPa3BbgusszQ
+i-4i5vpDVzDizjgGeYkeoK2E,Bo Lundgren,1999-09-04,2003-10-25,i-F6Stwe8wVnSPa3BbgusszQ
+i-XgRZtFgzPDL7KcwsDvGVej,Fredrik Reinfeldt,2003-10-25,2015-01-10,i-F6Stwe8wVnSPa3BbgusszQ
+i-CajxChHCyySL6R6AQNT1bF,Anna Kinberg Batra,2015-01-10,2017-08-25,i-F6Stwe8wVnSPa3BbgusszQ
+i-bRyJHEKb5DCkicXkuZwMY,Ulf Kristersson,2017-10-01,,i-F6Stwe8wVnSPa3BbgusszQ
+i-ViDKs1694HGMUS3nPFJ9Vd,Erik Eriksson i Spraxkya,1916-12,1919,i-CNbGLyuzdkRJ2sJBBpzJit
+i-8aihZN7cw4opEHkSafGqrr,Johan Andersson i Raklösen,1920,1924-01,i-CNbGLyuzdkRJ2sJBBpzJit
+i-9gw6tCpchuRJcG4S3PU6wP,Johan Johansson i Kälkebo,1924,1928-06-22,i-CNbGLyuzdkRJ2sJBBpzJit
+i-95K5z35tn37uoiYoUqCBaa,Olof Olsson i Kullenbergstorp,1929-06-15,1934-06,i-CNbGLyuzdkRJ2sJBBpzJit
+i-QSvXYSPnCaog2kVQuZMYmX,Axel Pehrsson-Bramstorp,1934-06-16,1949-06-20,i-CNbGLyuzdkRJ2sJBBpzJit
+i-KaEwnQ53dsfqZGV8fcpYbX,Gunnar Hedlund,1949-06-20,1957-07-02,i-CNbGLyuzdkRJ2sJBBpzJit
+i-KaEwnQ53dsfqZGV8fcpYbX,Gunnar Hedlund,1957-07-03,1971-06-21,i-UiFZiVNo3YgVfyN93Qigiv
+i-PDvEfAmYAgGTBhkGvyY7F4,Thorbjörn Fälldin,1971-06-21,1985-12-05,i-UiFZiVNo3YgVfyN93Qigiv
+i-XrDegv7uQGz4MSbepK4txd,Karin Söder,1985-12-05,1987-01-02,i-UiFZiVNo3YgVfyN93Qigiv
+i-FrizKF8qiYUeCD64QhzzFt,Olof Johansson,1987-02-21,1998-06-15,i-UiFZiVNo3YgVfyN93Qigiv
+i-GSfuaZB2iKY7EQ9cNr63sp,Lennart Daléus,1998-06-15,2001-03-19,i-UiFZiVNo3YgVfyN93Qigiv
+i-PRFN1BS8QWUhjjGAM8w3Fj,Maud Olofsson,2001-03-19,2011-09-23,i-UiFZiVNo3YgVfyN93Qigiv
+i-NirXfc8JiwP3Ssuz3NR6e2,Annie Lööf,2011-09-23,2023-02-02,i-UiFZiVNo3YgVfyN93Qigiv
+i-2B9CQsorTkxsV4aDV5kmNj,Muharrem Demirok,2023-02-02,2025-05-03,i-UiFZiVNo3YgVfyN93Qigiv
+i-FsQi9rLBPWwgHr8YrG1deY,Anna-Karin Hatt,2025-05-03,2025-10-15,i-UiFZiVNo3YgVfyN93Qigiv
+i-AmkEPQHyLbWFNYdCQzmzAu,Elisabeth Thand Ringqvist,2025-11-13,,i-UiFZiVNo3YgVfyN93Qigiv
+i-PfWLQcWc1zHmdsEJAzj7vd,Sixten von Friesen,1900-01-16,1905,i-JmAkiEUKt5ZBgaCKGCMNu2
+i-Hr1HTFqifdBa5H1eAGcaEu,Karl Staaff,1904,1904,i-JmAkiEUKt5ZBgaCKGCMNu2
+i-Hr1HTFqifdBa5H1eAGcaEu,Karl Staaff,1907,1915,i-JmAkiEUKt5ZBgaCKGCMNu2
+i-KLVdWuEH3iyC7Ws5pZeVNK,Daniel Persson i Tällberg,1915,1917,i-JmAkiEUKt5ZBgaCKGCMNu2
+i-EMnZ9doEs8MQVGY2nAGkkE,Nils Edén,1917,1923,i-JmAkiEUKt5ZBgaCKGCMNu2
+i-SmANBDpEMp49AgxGMgLJX,Ernst Beckman,1902,1914,i-6phCStV52pp0GuBufmEi9g
+i-H51hFF5ej5tCePg4YqjSsq,Axel Schotte,1914,1917,i-6phCStV52pp0GuBufmEi9g
+i-KLVdWuEH3iyC7Ws5pZeVNK,Daniel Persson i Tällberg,1917,1918,i-6phCStV52pp0GuBufmEi9g
+i-4kz1fC2gQwdiC7G6RzQ2SK,Raoul Hamilton,1919,1923,i-6phCStV52pp0GuBufmEi9g
+i-Xk2ZY1AVkT44C7mHKMPyhE,Carl Gustaf Ekman,1923-06-06,1933-03,i-V7MTfG5XaAmjbSDtLkyyfc
+i-3D7Cfk47LUcjbeGff3k8fV,Felix Hamrin,1933-01-10,1934-08-05,i-V7MTfG5XaAmjbSDtLkyyfc
+i-WLU6NbD2RqdzNAUFs2iT52,Ola Jeppsson i Mörrum,1933-03,1934-08-05,i-V7MTfG5XaAmjbSDtLkyyfc
+i-JSniSV7GLnNo4eioo6Paqg,Eliel Löfgren,1923-10-07,1930-06-07,i-9fghptqkyNzTVdA8knRCGq
+,E. A. Nilson,1924-01-10,1925-01-10,i-9fghptqkyNzTVdA8knRCGq
+i-JSniSV7GLnNo4eioo6Paqg,Eliel Löfgren,1925-01-10,1934-08-05,i-9fghptqkyNzTVdA8knRCGq
+i-4WEXv6PZpB3sB69uG9D7nN,Ernst Lyberg,1930-06-07,1932-06-12,i-9fghptqkyNzTVdA8knRCGq
+i-J2XMMheFYn2HnPhL5mPhfx,Karl Andersson,1933-01-24,1934-08-05,i-9fghptqkyNzTVdA8knRCGq
+i-3D7Cfk47LUcjbeGff3k8fV,Felix Hamrin,1934-08-05,1935-01-10,i-FpGjUCojANuvvwqsNXjcuu
+i-57VtU3DUgS6ebh11mtUQes,Gustaf Andersson i Rasjön,1935-01-10,1944-09-28,i-FpGjUCojANuvvwqsNXjcuu
+i-BqDGKscaLhUZHhaFFmx5pf,Bertil Ohlin,1944-09-28,1967-06-11,i-FpGjUCojANuvvwqsNXjcuu
+i-BtszRKWKgFfiTcr2r2Ek6j,Sven Wedén,1967-06-11,1969-09-26,i-FpGjUCojANuvvwqsNXjcuu
+i-Qz4kjjKSzCm5RwSxi2vkro,Gunnar Helén,1969-11-07,1975-11-07,i-FpGjUCojANuvvwqsNXjcuu
+i-8aNTXCV4f9MdU7Dz15ZXyB,Per Ahlmark,1975-11-07,1978-03-04,i-FpGjUCojANuvvwqsNXjcuu
+i-4uJEFdvmwfbMmozZhv5XDY,Ola Ullsten,1978-03-04,1983-10-01,i-FpGjUCojANuvvwqsNXjcuu
+i-MYV5TtBU5tQGwqDu4dq25s,Bengt Westerberg,1983-10-01,1990-11-23,i-FpGjUCojANuvvwqsNXjcuu
+i-MYV5TtBU5tQGwqDu4dq25s,Bengt Westerberg,1990-11-24,1995-02-04,i-Hm85EQfFmbYuYFPjpXtuCj
+i-NTXLkayNLx1xKQsGQibNYd,Maria Leissner,1995-02-04,1997-03-15,i-Hm85EQfFmbYuYFPjpXtuCj
+i-NZES3NTTAs3ZaBTU3RVkYE,Lars Leijonborg,1997-03-15,2007-09-07,i-Hm85EQfFmbYuYFPjpXtuCj
+i-AvFShRZVEyBV61S19AKNGK,Jan Björklund,2007-09-07,2015-11-22,i-Hm85EQfFmbYuYFPjpXtuCj
+i-AvFShRZVEyBV61S19AKNGK,Jan Björklund,2015-11-23,2019-06-28,i-Kpkv9BSujEEJp1S4rDiDt7
+i-Rtt4vV6Vr1WnfJAi2Dn9hN,Nyamko Sabuni,2019-06-28,2022-04-08,i-Kpkv9BSujEEJp1S4rDiDt7
+i-PyYxwdbw2KYpXyCWKWHmmT,Johan Pehrson,2022-04-08,2025-06-24,i-Kpkv9BSujEEJp1S4rDiDt7
+,Simona Mohamsson,2025-06-24,,i-Kpkv9BSujEEJp1S4rDiDt7
+,Eva Sahlin,1981-10-04,1984-06-02,i-Qha9NerKBigcjJXgoRk4Md
+i-FaHZVPWVR2eB2WbWdES1dK,Ragnhild Pohanka,1984-06-02,1986-05,i-Qha9NerKBigcjJXgoRk4Md
+i-EF4gEp1CrEwnV5AnkFU4P2,Per Gahrton,1984-06-02,1985-09-29,i-Qha9NerKBigcjJXgoRk4Md
+i-EfLrWUocZwsV2PVnPdzohZ,Birger Schlaug,1985-09-29,1986-05,i-Qha9NerKBigcjJXgoRk4Md
+i-5orH1EJN5hP5LGxnLXboj2,Eva Goës,1986-05,1988-10,i-Qha9NerKBigcjJXgoRk4Md
+i-EfLrWUocZwsV2PVnPdzohZ,Birger Schlaug,1986-05,1988-10,i-Qha9NerKBigcjJXgoRk4Md
+i-T3gdjsEDM8Rwzy9YJpgufQ,Inger Schörling,1988-09-28,1988-10-02,i-Qha9NerKBigcjJXgoRk4Md
+i-C5oSgDpxjTK7J31TqsPEwQ,Claes Roxbergh,1988-09-28,1988-10-02,i-Qha9NerKBigcjJXgoRk4Md
+,Fiona Björling,1988-10-02,1990-06,i-Qha9NerKBigcjJXgoRk4Md
+i-CjZkXimkoMyh995sWqXoSH,Anders Nordin,1988-10-02,1990-06,i-Qha9NerKBigcjJXgoRk4Md
+,Margareta Gisselberg,1990-06-14,1992-04,i-Qha9NerKBigcjJXgoRk4Md
+,Jan Axelsson,1990-06-14,1992-04,i-Qha9NerKBigcjJXgoRk4Md
+i-NAZHDwfGffE63ZZmJW4qqn,Marianne Samuelsson,1992-04-19,1999-05-14,i-Qha9NerKBigcjJXgoRk4Md
+i-EfLrWUocZwsV2PVnPdzohZ,Birger Schlaug,1992-04-19,2000-06-03,i-Qha9NerKBigcjJXgoRk4Md
+i-Q6T8pKy9pERdSQEuTcARyR,Lotta Nilsson Hedström,1999-05-14,2002-05-10,i-Qha9NerKBigcjJXgoRk4Md
+i-JyVEFshzVXajALX3xcvJad,Matz Hammarström,2000-06-03,2002-05-10,i-Qha9NerKBigcjJXgoRk4Md
+i-FvpsLGyVJwy2VnAqBbfthX,Maria Wetterstrand,2002-05-10,2011-05-21,i-Qha9NerKBigcjJXgoRk4Md
+i-9BUsH2Bn1bGihptNC5r7uq,Peter Eriksson,2002-05-10,2011-05-21,i-Qha9NerKBigcjJXgoRk4Md
+i-ST3KmJ7dwych9bUEkWZEu6,Åsa Romson,2011-05-21,2016-05-13,i-Qha9NerKBigcjJXgoRk4Md
+i-9CH1KbWwyrj8DRqAQB3Fza,Gustav Fridolin,2011-05-21,2019-05-04,i-Qha9NerKBigcjJXgoRk4Md
+i-CicdbyfBoitjsXT8ugY99b,Isabella Lövin,2016-05-13,2021-01-31,i-Qha9NerKBigcjJXgoRk4Md
+i-C2s3YhmmVmNkgvznmmnD4x,Per Bolund,2019-05-04,2023-11-18,i-Qha9NerKBigcjJXgoRk4Md
+i-PjQgLPLrkyDV2oYQfyuWq2,Märta Stenevi,2021-01-31,2024-04-28,i-Qha9NerKBigcjJXgoRk4Md
+i-6EELQ8G6wLhYTcTKBKGQdF,Daniel Helldén,2023-11-18,,i-Qha9NerKBigcjJXgoRk4Md
+i-PAgTpr3nkZRPEoiqjPKQAf,Amanda Lind,2024-04-28,,i-Qha9NerKBigcjJXgoRk4Md
+i-DVBTR4FnJMy9pff8g7tptN,Carl Winberg,1917-05-13,,i-SwzbNNYoyZYULLDiTu2zGP
+i-Xy8Q95HPbgxgm5iGyCyBLd,Zeth Höglund,1917-05-13,,i-SwzbNNYoyZYULLDiTu2zGP
+i-Lee6HzC4SEXhUPAjMv9DZi,Ernst Åström,1918,1918,i-SwzbNNYoyZYULLDiTu2zGP
+i-UA8QjszavpQnNcqKo12DY2,Karl Kilbom,1918,1918,i-SwzbNNYoyZYULLDiTu2zGP
+i-Xy8Q95HPbgxgm5iGyCyBLd,Zeth Höglund,1919,1920,i-SwzbNNYoyZYULLDiTu2zGP
+i-Xy8Q95HPbgxgm5iGyCyBLd,Zeth Höglund,1921,1923,i-SwzbNNYoyZYULLDiTu2zGP
+i-Xy8Q95HPbgxgm5iGyCyBLd,Zeth Höglund,1921-03-28,1923,i-TQCUzfkvYhBFrXeQwXoENH
+i-UA8QjszavpQnNcqKo12DY2,Karl Kilbom,1921,1923,i-SwzbNNYoyZYULLDiTu2zGP
+i-UA8QjszavpQnNcqKo12DY2,Karl Kilbom,1921-03-28,1923,i-TQCUzfkvYhBFrXeQwXoENH
+i-Xy8Q95HPbgxgm5iGyCyBLd,Zeth Höglund,1923,1924-08,i-SwzbNNYoyZYULLDiTu2zGP
+i-Xy8Q95HPbgxgm5iGyCyBLd,Zeth Höglund,1923,1924-08,i-TQCUzfkvYhBFrXeQwXoENH
+i-UA8QjszavpQnNcqKo12DY2,Karl Kilbom,1924-08,1929-11-30,i-TQCUzfkvYhBFrXeQwXoENH
+i-Tym6Aw1gBuoRJqfGXa3Wdy,Nils Flyg,1924-08,1929-11-30,i-TQCUzfkvYhBFrXeQwXoENH
+i-JFfGPzij9DwmfbXD4RuxyR,Sven Linderot,1929-11-30,1951-03,i-TQCUzfkvYhBFrXeQwXoENH
+i-GPYC16egTa8Yn3wguN6WLg,Hilding Hagberg,1951-03,1964-01-06,i-TQCUzfkvYhBFrXeQwXoENH
+i-FiisfXYQcUpGymcboYQpoF,C.-H. Hermansson,1964-01-06,1967-05-15,i-TQCUzfkvYhBFrXeQwXoENH
+i-FiisfXYQcUpGymcboYQpoF,C.-H. Hermansson,1967-05-16,1975-03-13,i-2SVXJYpXaRHXxbWRcbRd5N
+i-5wPAQ1MDLRTsW1XngYcD46,Lars Werner,1975-03-13,1990-05-26,i-2SVXJYpXaRHXxbWRcbRd5N
+i-5wPAQ1MDLRTsW1XngYcD46,Lars Werner,1990-05-27,1993-01-07,i-CJb7bcc1eZcehvGarg8GpB
+i-LzYBGnvuhNHdQ7LQKPA6UJ,Gudrun Schyman,1993-01-07,2003-01-26,i-CJb7bcc1eZcehvGarg8GpB
+i-LB9Tn6B1RXiAHZEWEK1hYC,Ulla Hoffmann,2003-01-26,2004-02-20,i-CJb7bcc1eZcehvGarg8GpB
+i-HpwkrkkrFd1MRPixHrr8q1,Lars Ohly,2004-02-20,2012-01-06,i-CJb7bcc1eZcehvGarg8GpB
+i-PPZKpwNr5kqkWArvESGC5X,Jonas Sjöstedt,2012-01-06,2020-10-31,i-CJb7bcc1eZcehvGarg8GpB
+i-8voj19hLWTGJHkxNP79tRb,Nooshi Dadgostar,2020-10-31,,i-CJb7bcc1eZcehvGarg8GpB
+,Birger Ekstedt,1964-04-15,1972-07-05,i-B79rKJX4ZV61ozevGt8JLL
+,"Tremannapresidium (Åke Gafvelin, Sven Enlund, Alf Svensson)",1972-07-05,1973-01-20,i-B79rKJX4ZV61ozevGt8JLL
+i-WCrN5vpCNm6z9SvfXfby4e,Alf Svensson,1973-01-20,1996-06-28,i-B79rKJX4ZV61ozevGt8JLL
+i-WCrN5vpCNm6z9SvfXfby4e,Alf Svensson,1996-06-29,2004-04-03,i-BRRSButj7zSqB1u7zD6hod
+i-8BTYtQ95yRpC5syyC4aHoY,Göran Hägglund,2004-04-03,2015-04-25,i-BRRSButj7zSqB1u7zD6hod
+i-UgG6CqxVABxx5Hq9mpcZ8M,Ebba Busch,2015-04-25,,i-BRRSButj7zSqB1u7zD6hod
+,Leif Ericsson,1988-02-06,1989,i-Cb6hYmJf4EDxesFRgErquJ
+,Johnny Berg,1988-02-06,1989,i-Cb6hYmJf4EDxesFRgErquJ
+,Ola Sundberg,1989,1990,i-Cb6hYmJf4EDxesFRgErquJ
+,Anders Klarström,1989,1995,i-Cb6hYmJf4EDxesFRgErquJ
+,Madeleine Larsson,1990,1992,i-Cb6hYmJf4EDxesFRgErquJ
+i-Uj8BaU1ExHbpKGVGx2k7Ed,Mikael Jansson,1995,2005-05-07,i-Cb6hYmJf4EDxesFRgErquJ
+i-DCyBt1A1WiAhi5tm5k4A7H,Jimmie Åkesson,2005-05-07,,i-Cb6hYmJf4EDxesFRgErquJ
+i-4sEtGRPnuog5ACjegAtakj,Mattias Karlsson,2014-10-17,2015-04,i-Cb6hYmJf4EDxesFRgErquJ
+i-g5oS8RSWuaximcHXWswPQ,Bert Karlsson,1991-02-04,1991-02-18,i-YYGgpk3VEG9XW1wZTzUShT
+i-SfnrsjEZBg9vdQjkU5VSZ2,Ian Wachtmeister,1991-02-25,1994-04-09,i-YYGgpk3VEG9XW1wZTzUShT
+i-9YGU9DsvbhLihhVNnvsKND,Harriet Colliander,1994-04-09,1994-06-05,i-YYGgpk3VEG9XW1wZTzUShT
+i-5kCq5AaWoBgtDWjyW8fFRC,Vivianne Franzén,1994-06-05,1997-01-18,i-YYGgpk3VEG9XW1wZTzUShT
+,Gunilla Aastrup Persson,1994-07-28,1994-08-20,i-YYGgpk3VEG9XW1wZTzUShT
+,Bengt G. Andersson,1997-01-18,1997-05-25,i-YYGgpk3VEG9XW1wZTzUShT
+i-XAZuDYpjMWVDmo4L97UiJw,John Bouvin,1997-05-25,1998-05,i-YYGgpk3VEG9XW1wZTzUShT
+,Per Anders Gustavsson,1998-05,1999,i-YYGgpk3VEG9XW1wZTzUShT
+i-ALh3PHXDXv6YrkEMi4FuSj,Ulf Eriksson,1999,2000-02-25,i-YYGgpk3VEG9XW1wZTzUShT
+i-Tym6Aw1gBuoRJqfGXa3Wdy,Nils Flyg,1934-05-01,1943-01-09,i-SeXPXWPfyJxdeuuFtkdhxh
+,Agaton Blom,1943-01-09,1943,i-SeXPXWPfyJxdeuuFtkdhxh


### PR DESCRIPTION
This builds on #149 for the parties to line up properly.

The csv contains both swerik member id and name since some leaders where never members of parliament so they do not have a swerik member id. It's a bit of double booking. If anyone has a better idea about how to solve it ping me.

This is Claude code that has scraped this and built the csv and I havent checked all the sources but skimming it looks pretty good.

Tvåkammartiden:
<img width="1419" height="142" alt="Screenshot 2026-08-11 at 00 04 19" src="https://github.com/user-attachments/assets/dd968c1f-8aff-4b3d-8924-7bad79986949" />

Enkammartiden:
<img width="1421" height="137" alt="Screenshot 2026-08-11 at 00 04 02" src="https://github.com/user-attachments/assets/7d48af78-9353-454a-ae37-2d3ea6335d2e" />


evidence:
## Socialdemokraterna (`i-VS8ddgxigwL5TceKtXGApS`)

| Datum (DN) | Ledare | Swerik-id | Typ | Ort | DN-källa |
|---|---|---|---|---|---|
| 1925-04-19 | F.V. Thorsson föreslås till partiordförande av partistyrelsen — valet skulle underställas allmän omröstning inom partiet; Thorsson avled 5 maj innan den fullbordats | – | nominerad (ej fullbordat val) | Stockholm | [DN 1925-04-20](https://arkivet.dn.se/tidning/1925-04-20/105/1) (läst i skann) |
| 1925-11-15 | Per Albin Hansson — partistyrelsen beslutar att VU-ordföranden ”tillsvidare skall fungera som ordförande” | `i-L7nvZ56RferP78KNpz2Uh1` | **tf** (partistyrelsebeslut) | Stockholm | [DN 1925-11-17 s.9](https://arkivet.dn.se/tidning/1925-11-17/313/9) (läst i skann) |
| 1928-06-08 | Per Albin Hansson | `i-L7nvZ56RferP78KNpz2Uh1` | vald (kongress) | okänd | [DN 1928-06-09](https://arkivet.dn.se/tidning/1928-06-09/155/11) |
| 1946-10-07 (≤) | Gustav Möller | `i-4Mr7D9BCozgkT5mSiFk6Gv` | **tf** (vice ordförande ”till rodret i avvaktan”) | – | [DN 1946-10-08](https://arkivet.dn.se/tidning/1946-10-08/11161-274/4) |
| 1946-10-09 | Tage Erlander | `i-8fp2gLHtWqnYwFqeVLu5w8` | vald (partistyrelsen) | Stockholm | [DN 1946-10-10](https://arkivet.dn.se/tidning/1946-10-10/11161-276/1) |
| 1969-10-01 | Olof Palme | `i-DKX1MP4aaNtFZSpMKXCwY` | vald (kongress) | okänd | [DN 1969-10-02](https://arkivet.dn.se/tidning/1969-10-02/11171-267/21) |
| 1986-03-01 (≤) | Ingvar Carlsson (formellt vald på kongressen 1987-09-21, Stockholm) | `i-WYkrZExE7jfwHjmfH1DPwg` | tillträdde (partistyrelsenivå, efter mordet på Palme) | Stockholm | [DN 1986-03-02](https://arkivet.dn.se/tidning/1986-03-02/59/1) |
| 1996-03-15 | Göran Persson | `i-3kVCtR7mCK6mW2F6oaBMR5` | vald (extrakongress) | Stockholm | [DN 1996-03-16](https://arkivet.dn.se/tidning/1996-03-16/11175-74/6) |
| 2007-03-17 | Mona Sahlin | `i-GFJcxAB9fyzG2VN1HakscJ` | vald (extrakongress) | Stockholm | [DN 2007-03-18](https://arkivet.dn.se/tidning/2007-03-18/123382-75/1) |
| 2011-03-25 | Håkan Juholt | `i-UojdP4mF9dqkxf3QQ9oPFe` | vald (extrakongress) | Stockholm | [DN 2011-03-26](https://arkivet.dn.se/tidning/2011-03-26/131379-83/1) |
| 2012-01-27 | Stefan Löfven (installationstal på kongressen i Göteborg 2013) | `i-Xzt52E3ZeNyJ9HLW4B5Sk1` | vald (partistyrelsen, ej kongress) | Stockholm | [DN 2012-01-27](https://arkivet.dn.se/tidning/2012-01-27/134593-25/11) |
| 2021-11-04 | Magdalena Andersson | `i-74hLepsvAgUMEvVVtBCGuc` | vald (kongress) | Göteborg | [DN 2021-11-08](https://arkivet.dn.se/tidning/2021-11-08/312/7) |

## Högern / Moderaterna (Högerns riksdagsgrupp `i-4nyjRorziqEDtDmp1ZXDoP`, Högerpartiet `i-3A4u29WVtvfu8i1KwuPEeE`, Moderata samlingspartiet `i-F6Stwe8wVnSPa3BbgusszQ`)

| Datum (DN) | Ledare | Swerik-id | Typ | Ort | DN-källa |
|---|---|---|---|---|---|
| 1935-06-03 | Gösta Bagge | `i-CU4eSFiFKKx8yk9jS92iFV` | vald (riksstämma) | okänd | [DN 1935-06-04](https://arkivet.dn.se/tidning/1935-06-04/150/1) |
| 1944-12-09 (≤) | Fritiof Domö | `i-PRkToj2ss6C9sjWtUtqNNh` | vald | okänd | [DN 1944-12-10](https://arkivet.dn.se/tidning/1944-12-10/11161-337/1) |
| 1950-01-09 (≤) | Jarl Hjalmarson | `i-2gvrXtH5sAT9PgXsCVpQSW` | tillträdde (mottog klubban av Domö) | okänd | [DN 1950-01-10](https://arkivet.dn.se/tidning/1950-01-10/11161-8/5) |
| 1961-08-28 | Gunnar Heckscher | `i-S8m3fmgdhJmz5CbDpVBctA` | vald (extra riksstämma, 164–36) | Stockholm (Konserthuset) | [DN 1961-08-29](https://arkivet.dn.se/tidning/1961-08-29/11165-233/1) |
| 1965-06-01 | Yngve Holmberg *(party-leaders.json:s 1965-04-05 är fel — DN-verifierat: Heckscher var ledare till stämman; succession öppen hela april)* | `i-MTA6YhhXtmnmGGwd2tXXRL` | vald (riksstämma) | Stockholm | [DN 1965-06-02](https://arkivet.dn.se/tidning/1965-06-02/11166-147/9) |
| 1970-11-14 | Gösta Bohman | `i-LQKP5CDY62YpFZWUbs7QiW` | vald (extra partistämma, 132–82) | okänd | [DN 1970-11-15](https://arkivet.dn.se/tidning/1970-11-15/11171-310/62) |
| 1981-10-25 | Ulf Adelsohn | `i-Pe1ftVDt68xexZMLUFEKsL` | vald (partistämma) | Falun | [DN 1981-10-26](https://arkivet.dn.se/tidning/1981-10-26/11171-291/2) |
| 1986-08-23 | Carl Bildt | `i-AZnaWEAg22YQ3HzVMfNSHR` | vald (extra stämma) | okänd | [DN 1986-08-24](https://arkivet.dn.se/tidning/1986-08-24/228/64) |
| 1999-09-04 | Bo Lundgren | `i-4i5vpDVzDizjgGeYkeoK2E` | vald (ordinarie partistämma) | Stockholm | [DN 1999-09-05](https://arkivet.dn.se/tidning/1999-09-05/11184-240/2) |
| 2003-10-25 | Fredrik Reinfeldt | `i-XgRZtFgzPDL7KcwsDvGVej` | vald (partistämma, enig) | Stockholm | [DN 2003-10-26](https://arkivet.dn.se/tidning/2003-10-26/11184-291/8) |
| 2015-01-10 | Anna Kinberg Batra (partiets första kvinnliga ledare) | `i-CajxChHCyySL6R6AQNT1bF` | vald (extra partistämma) | okänd | [DN 2015-01-11](https://arkivet.dn.se/tidning/2015-01-11/134593-9/1) |
| 2017-10-01 | Ulf Kristersson | `i-bRyJHEKb5DCkicXkuZwMY` | vald (extra partistämma) | okänd | [DN 2017-10-02](https://arkivet.dn.se/tidning/2017-10-02/134627-267/10) |

Moderaterna är det enda partiet helt utan DN-belagd interimsledare — avgående
ledare satt kvar till efterträdarvalet vid samtliga skiften.

## Bondeförbundet / Centerpartiet (Bondeförbundet `i-CNbGLyuzdkRJ2sJBBpzJit`, Centerpartiet `i-UiFZiVNo3YgVfyN93Qigiv`)

| Datum (DN) | Ledare | Swerik-id | Typ | Ort | DN-källa |
|---|---|---|---|---|---|
| 1929-06-15 | Olof Olsson i Kullenbergstorp | `i-95K5z35tn37uoiYoUqCBaa` | vald (riksstämma) | okänd | [DN 1929-06-16](https://arkivet.dn.se/tidning/1929-06-16/161/26) |
| 1934-06-16 (≤) | Axel Pehrsson-Bramstorp | `i-QSvXYSPnCaog2kVQuZMYmX` | vald (riksstämma) | Linköping | [DN 1934-06-17](https://arkivet.dn.se/tidning/1934-06-17/161/3) |
| 1949-06-20 | Gunnar Hedlund | `i-KaEwnQ53dsfqZGV8fcpYbX` | vald (riksstämma) | Falun | [DN 1949-06-21](https://arkivet.dn.se/tidning/1949-06-21/11161-164/28) |
| 1971-06-21 | Thorbjörn Fälldin | `i-PDvEfAmYAgGTBhkGvyY7F4` | vald (riksstämma) | Halmstad | [DN 1971-06-22](https://arkivet.dn.se/tidning/1971-06-22/11171-166/1) |
| 1985-12-06 (≤) | Karin Söder | `i-XrDegv7uQGz4MSbepK4txd` | **tf** (”fungerande partiledaren” efter Fälldins avgång) | – | [DN 1985-12-07](https://arkivet.dn.se/tidning/1985-12-07/333/8) |
| 1986-06-16 (≤) | Karin Söder formellt vald | `i-XrDegv7uQGz4MSbepK4txd` | vald (riksstämma) | Uppsala | [DN 1986-06-17](https://arkivet.dn.se/tidning/1986-06-17/11175-161/8) |
| 1987-02-21 | Olof Johansson (Söder avgick 1987-01-02) | `i-FrizKF8qiYUeCD64QhzzFt` | vald (extra partistämma, enhälligt) | okänd | [DN 1987-02-22](https://arkivet.dn.se/tidning/1987-02-22/51/1) |
| 1998-06-15 | Lennart Daléus | `i-GSfuaZB2iKY7EQ9cNr63sp` | vald (partistämma) | Sunne | [DN 1998-06-16](https://arkivet.dn.se/tidning/1998-06-16/11184-160/1) |
| 2001-03-19 | Maud Olofsson | `i-PRFN1BS8QWUhjjGAM8w3Fj` | vald (extra stämma) | Stockholm | [DN 2001-03-20](https://arkivet.dn.se/tidning/2001-03-20/11184-77/8) |
| 2011-09-23 | Annie Lööf | `i-NirXfc8JiwP3Ssuz3NR6e2` | vald (partistämma) | Åre | [DN 2011-09-24](https://arkivet.dn.se/tidning/2011-09-24/134593-259/1) |
| 2023-02-02 | Muharrem Demirok | `i-2B9CQsorTkxsV4aDV5kmNj` | vald (extra stämma) | Helsingborg | [DN 2023-02-03](https://arkivet.dn.se/tidning/2023-02-03/34/8) |
| 2025-05-03 | Anna-Karin Hatt (avgick 2025-10-15) | `i-FsQi9rLBPWwgHr8YrG1deY` | vald (extra stämma) | Stockholm (Södermalm) | [DN 2025-05-04](https://arkivet.dn.se/tidning/2025-05-04/124/12) |
| 2025-11-13 | Elisabeth Thand Ringqvist | `i-AmkEPQHyLbWFNYdCQzmzAu` | vald (ordinarie partistämma) | Karlstad | [DN 2025-11-14](https://arkivet.dn.se/tidning/2025-11-14/318/14) |

## Liberalerna (inkl. de splittrade partierna 1923–1934) (Frisinnade folkpartiet `i-V7MTfG5XaAmjbSDtLkyyfc`, Frisinnade landsföreningen `i-6phCStV52pp0GuBufmEi9g`, Liberala riksdagspartiet `i-9fghptqkyNzTVdA8knRCGq`, Folkpartiet `i-FpGjUCojANuvvwqsNXjcuu`, Folkpartiet liberalerna `i-Hm85EQfFmbYuYFPjpXtuCj`, Liberalerna `i-Kpkv9BSujEEJp1S4rDiDt7`)

Under splittringen hade **båda** partierna två skilda ledarposter, vilket DN säger
uttryckligen i januari 1933: ”Det frisinnade partiet har alltså från detta nu två
ledare, en för Landsföreningen och en för riksdagspartiet”
([DN 1933-01-12 s.3](https://arkivet.dn.se/tidning/1933-01-12/10/3)). Tabellerna
nedan skiljer därför på **partiorganisationens** ordförande (verkställande
utskottet) och **riksdagsgruppens** ordförande. Fullständiga citat och sidbilder
finns i liberalerna.md.

### Frisinnade folkpartiet / Frisinnade landsföreningen (1923–1934) (Frisinnade folkpartiet `i-V7MTfG5XaAmjbSDtLkyyfc`, Frisinnade landsföreningen `i-6phCStV52pp0GuBufmEi9g`)

| Datum (DN) | Ledare | Swerik-id | Post | DN-källa |
|---|---|---|---|---|
| 1923–1933-03 | C. G. Ekman | `i-Xk2ZY1AVkT44C7mHKMPyhE` | partiorganisationen (VU-ordförande) — satt kvar genom Kreugerkrisen aug 1932 (”Ledarfrågan blir uppskjuten tills vidare”), ombedd återkomma 1933-01-08 (≤), stannade 1933-01-24 (≤) | [DN 1932-08-12](https://arkivet.dn.se/tidning/1932-08-12/11161-217/1), [DN 1933-01-25](https://arkivet.dn.se/tidning/1933-01-25/23/1) |
| 1924-01-10 | C. G. Ekman | `i-Xk2ZY1AVkT44C7mHKMPyhE` | partiets ledare + FK-gruppens ordförande (Raoul Hamilton ledde AK-gruppen) | [DN 1924-01-11](https://arkivet.dn.se/tidning/1924-01-11/10/1) |
| 1933-01-10 | Felix Hamrin | `i-3D7Cfk47LUcjbeGff3k8fV` | riksdagsgruppens ordförande — Ekman satt inte längre i riksdagen | [DN 1933-01-11](https://arkivet.dn.se/tidning/1933-01-11/9/4) |
| 1933-03-19 (≤) | Ola Jeppsson | `i-WLU6NbD2RqdzNAUFs2iT52` | partiorganisationen — ”De frisinnades nye ledare”; självskriven VU-ordförande vid landsmötet 13–14 maj 1934 | [DN 1933-03-20](https://arkivet.dn.se/tidning/1933-03-20/77/8) |

Riksdagsgruppens ordförande 1925–1932 är inte DN-belagd i dessa sökningar (Ekman
var statsminister 1926–28 och 1930–32).

### Sveriges liberala parti / Liberala riksdagspartiet (1923–1934) (`i-9fghptqkyNzTVdA8knRCGq`)

| Datum (DN) | Ledare | Swerik-id | Post | DN-källa |
|---|---|---|---|---|
| 1923-10-07 | Eliel Löfgren | `i-JSniSV7GLnNo4eioo6Paqg` | partiorganisationen (VU-ordförande) från partibildningen | [DN 1924-05-07](https://arkivet.dn.se/tidning/1924-05-07/124/4) |
| 1924-01-10 | E. A. Nilson | – | riksdagspartiets ordförande (Bror Petrén ledde FK-gruppen) | [DN 1924-01-11](https://arkivet.dn.se/tidning/1924-01-11/10/1) |
| 1925-01-10 | Eliel Löfgren | `i-JSniSV7GLnNo4eioo6Paqg` | riksdagsgruppens ordförande (efter Nilson), omvald 1933-01-10 | [DN 1925-01-11](https://arkivet.dn.se/tidning/1925-01-11/9/10) |
| 1930-06-07 | Ernst Lyberg | `i-4WEXv6PZpB3sB69uG9D7nN` | partiorganisationen — efterträder Löfgren vid landsmötet; hade enligt DN endast provisoriskt åtagit sig posten | [DN 1930-06-08](https://arkivet.dn.se/tidning/1930-06-08/153/9) |
| 1932-06-12 | *(vakant)* | – | Lyberg avgår vid landsmötet; posten vakant ~7 månader | [DN 1932-06-13](https://arkivet.dn.se/tidning/1932-06-13/158/5) |
| 1933-01-24 (≤) | K. A. Andersson | `i-J2XMMheFYn2HnPhL5mPhfx` | partiorganisationen — VU utser ”ledamoten av första kammaren byråchefen K. A. Andersson” | [DN 1933-01-25](https://arkivet.dn.se/tidning/1933-01-25/23/3) |

### Folkpartiet / Folkpartiet liberalerna / Liberalerna (1934–) (Folkpartiet `i-FpGjUCojANuvvwqsNXjcuu`, Folkpartiet liberalerna `i-Hm85EQfFmbYuYFPjpXtuCj`, Liberalerna `i-Kpkv9BSujEEJp1S4rDiDt7`)

| Datum (DN) | Ledare | Swerik-id | Typ | Ort | DN-källa |
|---|---|---|---|---|---|
| 1935-01-10 (≤) | Gustaf Andersson i Rasjön (efter Felix Hamrin, FP:s förste ledare från sammanslagningen 1934-08-05) | `i-57VtU3DUgS6ebh11mtUQes` | vald (riksdagsgruppen) | Stockholm | [DN 1935-01-11](https://arkivet.dn.se/tidning/1935-01-11/10/3) |
| 1944-09-28 (≤) | Bertil Ohlin | `i-BqDGKscaLhUZHhaFFmx5pf` | vald | okänd | [DN 1944-09-29](https://arkivet.dn.se/tidning/1944-09-29/11161-265/1) |
| 1967-06-11 (≤) | Sven Wedén | `i-BtszRKWKgFfiTcr2r2Ek6j` | vald (landsmöte) | Sundsvall | [DN 1967-06-12](https://arkivet.dn.se/tidning/1967-06-12/11171-156/1) |
| 1969-11-07 | Gunnar Helén (Wedén avgick av hälsoskäl sept 1969) | `i-Qz4kjjKSzCm5RwSxi2vkro` | vald (extra landsmöte, enhälligt) | okänd | [DN 1969-11-08](https://arkivet.dn.se/tidning/1969-11-08/11171-303/1) |
| 1975-11-07 (≤) | Per Ahlmark | `i-8aNTXCV4f9MdU7Dz15ZXyB` | vald (landsmöte) | Stockholm | [DN 1975-11-08](https://arkivet.dn.se/tidning/1975-11-08/11171-303/11) |
| 1978-03-04 | Ola Ullsten | `i-4uJEFdvmwfbMmozZhv5XDY` | vald (extra landsmöte) | Stockholm | [DN 1978-03-05](https://arkivet.dn.se/tidning/1978-03-05/11172-62/6) |
| 1983-10-01 | Bengt Westerberg | `i-MYV5TtBU5tQGwqDu4dq25s` | vald (extra landsmöte) | okänd | [DN 1983-10-02](https://arkivet.dn.se/tidning/1983-10-02/267/8) |
| 1995-02-04 | Maria Leissner | `i-NTXLkayNLx1xKQsGQibNYd` | vald (extra landsmöte, 81–77 mot Anne Wibble) | okänd | [DN 1995-02-05](https://arkivet.dn.se/tidning/1995-02-05/11175-34/7) |
| 1997-03-15 | Lars Leijonborg | `i-NZES3NTTAs3ZaBTU3RVkYE` | vald (extra landsmöte) | okänd | [DN 1997-03-15](https://arkivet.dn.se/tidning/1997-03-15/11184-72/1) |
| 2007-09-07 | Jan Björklund | `i-AvFShRZVEyBV61S19AKNGK` | vald (landsmöte) | Västerås | [DN 2007-09-09](https://arkivet.dn.se/tidning/2007-09-09/123382-244/116) |
| 2019-06-28 | Nyamko Sabuni | `i-Rtt4vV6Vr1WnfJAi2Dn9hN` | vald (extra landsmöte) | Stockholm | [DN 2019-06-29](https://arkivet.dn.se/tidning/2019-06-29/134593-172/7) |
| 2022-04-08 | Johan Pehrson (”ska leda partiet över valdagen”) | `i-PyYxwdbw2KYpXyCWKWHmmT` | **tf** (ställföreträdande efter Sabunis avgång) | – | [DN 2022-04-09](https://arkivet.dn.se/tidning/2022-04-09/99/2) |
| 2022-11-26 (≤) | Johan Pehrson ordinarie | `i-PyYxwdbw2KYpXyCWKWHmmT` | vald (extra landsmöte) | okänd | [DN 2022-11-27](https://arkivet.dn.se/tidning/2022-11-27/331/90) |
| 2025-06-24 | Simona Mohamsson | – | vald (Almedalen) | Visby | [DN 2025-06-24](https://arkivet.dn.se/tidning/2025-06-24/175/1) |

## SKP / VPK / Vänsterpartiet (Sveriges kommunistiska parti `i-TQCUzfkvYhBFrXeQwXoENH`, Vänsterpartiet Kommunisterna `i-2SVXJYpXaRHXxbWRcbRd5N`, Vänsterpartiet `i-CJb7bcc1eZcehvGarg8GpB`)

| Datum (DN) | Ledare | Swerik-id | Typ | Ort | DN-källa |
|---|---|---|---|---|---|
| 1929-10-10 (≤) | Sven Linderot (i ledartrio efter partisprängningen; formellt val ej funnet, titeln partiordförande belagd 1939) | `i-JFfGPzij9DwmfbXD4RuxyR` | oklart | – | [DN 1929-10-11](https://arkivet.dn.se/tidning/1929-10-11/277/6) |
| 1951-03-23/26 | Hilding Hagberg | `i-GPYC16egTa8Yn3wguN6WLg` | vald (15:e kongressen, påsken) | okänd | [DN 1951-03-28](https://arkivet.dn.se/tidning/1951-03-28/11161-82/24) |
| 1964-01-06 (≤) | C-H Hermansson | `i-FiisfXYQcUpGymcboYQpoF` | vald (20:e kongressen) | okänd | [DN 1964-01-07](https://arkivet.dn.se/tidning/1964-01-07/11166-5/24) |
| 1975-03-13 | Lars Werner | `i-5wPAQ1MDLRTsW1XngYcD46` | tillträdde (24:e kongressen) | okänd | [DN 1975-03-14](https://arkivet.dn.se/tidning/1975-03-14/11171-71/34) |
| 1993-01-07 | Gudrun Schyman | `i-LzYBGnvuhNHdQ7LQKPA6UJ` | vald (kongress) | Göteborg | [DN 1993-01-08](https://arkivet.dn.se/tidning/1993-01-08/11175-6/7) |
| 2003-02-07 (≤) | Ulla Hoffmann (med Ingrid Burman), fram till kongressen 2004 | `i-LB9Tn6B1RXiAHZEWEK1hYC` | **tf** (partistyrelsebeslut efter Schymans avgång 2003-01-26) | – | [DN 2003-02-08](https://arkivet.dn.se/tidning/2003-02-08/11184-37/9) |
| 2004-02-20 | Lars Ohly | `i-HpwkrkkrFd1MRPixHrr8q1` | vald (kongress) | Stockholm | [DN 2004-02-21](https://arkivet.dn.se/tidning/2004-02-21/11184-50/10) |
| 2012-01-06 | Jonas Sjöstedt | `i-PPZKpwNr5kqkWArvESGC5X` | vald (kongress) | Uppsala | [DN 2012-01-07](https://arkivet.dn.se/tidning/2012-01-07/134593-5/2) |
| 2020-10-31 | Nooshi Dadgostar | `i-8voj19hLWTGJHkxNP79tRb` | vald (kongress) | okänd | [DN 2020-11-01](https://arkivet.dn.se/tidning/2020-11-01/165813-297/16) |

## KDS / Kristdemokraterna (Kristdemokratiska Samhällspartiet `i-B79rKJX4ZV61ozevGt8JLL`, Kristdemokraterna `i-BRRSButj7zSqB1u7zD6hod`)

| Datum (DN) | Ledare | Swerik-id | Typ | Ort | DN-källa |
|---|---|---|---|---|---|
| 1964-04-15 (≤) | Birger Ekstedt | – | presenterad som partiledare | Stockholm | [DN 1964-04-16](https://arkivet.dn.se/tidning/1964-04-16/103/1) |
| 1972-07 → 1973-01 | Tremannapresidium: Åke Gafvelin (sammankallande), Sven Enlund, Alf Svensson | – | **tf** (efter Ekstedts död ≤1972-07-06) | Stockholm/Gränna | [DN 1972-08-17](https://arkivet.dn.se/tidning/1972-08-17/11171-222/9) (läst i skann) |
| 1973-01-20 | Alf Svensson | `i-WCrN5vpCNm6z9SvfXfby4e` | vald (extra riksting) | Stockholm (Folkets hus) | [DN 1973-01-21](https://arkivet.dn.se/tidning/1973-01-21/11171-20/22) |
| 2004-04-03 | Göran Hägglund | `i-8BTYtQ95yRpC5syyC4aHoY` | vald (extra riksting) | Stockholm | [DN 2004-04-04](https://arkivet.dn.se/tidning/2004-04-04/11184-95/9) |
| 2015-04-25 | Ebba Busch (Thor) | `i-UgG6CqxVABxx5Hq9mpcZ8M` | vald (extra riksting) | ej funnen | [DN 2015-04-26 s.14](https://arkivet.dn.se/tidning/2015-04-26/134593-112/14) |

## Miljöpartiet (språkrör) (`i-Qha9NerKBigcjJXgoRk4Md`)

| Datum (DN) | Ledare | Swerik-id | Typ | Ort | DN-källa |
|---|---|---|---|---|---|
| 1981-10-04 (≤) | Eva Sahlin (roterande ordförande, kollektivt ledarskap; ”Sveriges första kvinnliga partiledare”) | – | utsedd | – | [DN 1981-10-05 s.1](https://arkivet.dn.se/tidning/1981-10-05/11171-270/1) |
| 1984-06-02 (≤) | Per Gahrton & Ragnhild Pohanka (första språkrören; systemet införs) | `i-EF4gEp1CrEwnV5AnkFU4P2` / `i-FaHZVPWVR2eB2WbWdES1dK` | valda (kongress) | Jakobsberg | [DN 1984-06-03 s.2](https://arkivet.dn.se/tidning/1984-06-03/149/2) |
| 1985-09-29 (≤) | Birger Schlaug ersätter Gahrton (Pohanka kvarstår) | `i-EfLrWUocZwsV2PVnPdzohZ` | vald | okänd | [DN 1985-09-29 s.8](https://arkivet.dn.se/tidning/1985-09-29/265/8) |
| våren 1986 | Eva Goës ersätter Pohanka (Schlaug kvarstår) | `i-5orH1EJN5hP5LGxnLXboj2` | vald (valet ej funnet i DN; första belägg juni 1986) | okänd | DN 1986-06-15 s.6 (ej länkad: ingen arkivlänk funnen) |
| 1988-09-28 (≤) | Inger Schörling & Claes Roxbergh (språkrör i riksdagen ”tills vidare”) | `i-T3gdjsEDM8Rwzy9YJpgufQ` / `i-C5oSgDpxjTK7J31TqsPEwQ` | **tf** | – | [DN 1988-09-28 s.14](https://arkivet.dn.se/tidning/1988-09-28/264/14) |
| 1988-10-01/02 | Fiona Björling & Anders Nordin | – / `i-CjZkXimkoMyh995sWqXoSH` | valda (förtroenderådet) | okänd | [DN 1988-10-03 s.1](https://arkivet.dn.se/tidning/1988-10-03/269/1) |
| 1990-06-14 (≤) | Margareta Gisselberg & Jan Axelsson | – / – | valda (kongress) | Jönköping | [DN 1990-06-15 s.12](https://arkivet.dn.se/tidning/1990-06-15/159/12) |
| 1992-04-17/19 | Birger Schlaug & Marianne Samuelsson | `i-EfLrWUocZwsV2PVnPdzohZ` / `i-NAZHDwfGffE63ZZmJW4qqn` | valda (kongress, påsken) | Trollhättan | [DN 1992-04-21 s.8](https://arkivet.dn.se/tidning/1992-04-21/108/8) |
| 1999-05-14 | Lotta Nilsson Hedström ersätter Samuelsson (Schlaug kvarstår) | `i-Q6T8pKy9pERdSQEuTcARyR` | vald (kongress) | Kristianstad | [DN 1999-05-15 s.1](https://arkivet.dn.se/tidning/1999-05-15/11184-129/1) |
| 2000-06-03 (≤) | Matz Hammarström ersätter Schlaug (Nilsson Hedström kvarstår) | `i-JyVEFshzVXajALX3xcvJad` | vald (kongress) | Vadstena | [DN 2000-06-04 s.7](https://arkivet.dn.se/tidning/2000-06-04/11184-152/7) |
| 2002-05-10 (≤) | Peter Eriksson & Maria Wetterstrand | `i-9BUsH2Bn1bGihptNC5r7uq` / `i-FvpsLGyVJwy2VnAqBbfthX` | valda (kongress) | Sundsvall | [DN 2002-05-11 s.1](https://arkivet.dn.se/tidning/2002-05-11/11184-125/1) |
| 2011-05-21 | Åsa Romson & Gustav Fridolin | `i-ST3KmJ7dwych9bUEkWZEu6` / `i-9CH1KbWwyrj8DRqAQB3Fza` | valda (kongress) | Karlstad | [DN 2011-05-22 s.10](https://arkivet.dn.se/tidning/2011-05-22/131379-137/10) (även s.2) |
| 2016-05-13 | Isabella Lövin ersätter Romson (Fridolin kvarstår) | `i-CicdbyfBoitjsXT8ugY99b` | vald (kongress) | Karlstad | [DN 2016-05-14 s.9](https://arkivet.dn.se/tidning/2016-05-14/134593-129/9) |
| 2019-05-04 | Per Bolund ersätter Fridolin (Lövin kvarstår) | `i-C2s3YhmmVmNkgvznmmnD4x` | vald (kongress) | Örebro | [DN 2019-05-05 s.1](https://arkivet.dn.se/tidning/2019-05-05/134593-120/1) |
| 2021-01-30/31 | Märta Stenevi ersätter Lövin (Bolund kvarstår) | `i-PjQgLPLrkyDV2oYQfyuWq2` | vald (digital extrakongress) | digital | [DN 2021-02-01 s.9](https://arkivet.dn.se/tidning/2021-02-01/32/9) |
| 2023-11-18 | Daniel Helldén ersätter Bolund, en rösts marginal (Stenevi kvarstår) | `i-6EELQ8G6wLhYTcTKBKGQdF` | vald (kongress) | Örebro | [DN 2023-11-19 s.1](https://arkivet.dn.se/tidning/2023-11-19/323/1) |
| 2024-04-28 | Amanda Lind ersätter Stenevi (Helldén kvarstår) | `i-PAgTpr3nkZRPEoiqjPKQAf` | vald (extrakongress) | okänd | [DN 2024-04-29 s.10](https://arkivet.dn.se/tidning/2024-04-29/120/10) |

## Sverigedemokraterna (`i-Cb6hYmJf4EDxesFRgErquJ`)

| Datum (DN) | Ledare | Swerik-id | Typ | Ort | DN-källa |
|---|---|---|---|---|---|
| 1989-08-02 (≤) | Anders Klarström (”den nye ledaren”; själva valet ej funnet i DN) | – | oklart | – | [DN 1989-08-03](https://arkivet.dn.se/tidning/1989-08-03/11171-207/14) |
| 1995 | Mikael Jansson (ej funnen i DN; första belägg retrospektivt 1998) | `i-Uj8BaU1ExHbpKGVGx2k7Ed` | oklart | – | [DN 1998-12-05](https://arkivet.dn.se/tidning/1998-12-05/11184-330/42) |
| 2005-05-08 (≤) | Jimmie Åkesson | `i-DCyBt1A1WiAhi5tm5k4A7H` | vald (årsmöte/kongress) | Norrköping | [DN 2005-05-09](https://arkivet.dn.se/tidning/2005-05-09/11184-123/9) |
| 2014-10-17 (≤) → 2015-04 | Mattias Karlsson (under Åkessons sjukskrivning; DN: ”vikarierande ledare”, ”tillförordnad partiledare”) | `i-4sEtGRPnuog5ACjegAtakj` | **tf** | – | [DN 2014-12-01](https://arkivet.dn.se/tidning/2014-12-01/134627-326/9) |

## Ny demokrati (`i-YYGgpk3VEG9XW1wZTzUShT`)

| Datum (DN) | Ledare | Swerik-id | Typ | Ort | DN-källa |
|---|---|---|---|---|---|
| 1991-02-04 | Bert Karlsson | `i-g5oS8RSWuaximcHXWswPQ` | utsedd (vid partibildandet; avgick ~18 feb, återkom som ”biträdande”) | Stockholm | [DN 1991-02-05 s.1](https://arkivet.dn.se/tidning/1991-02-05/11175-35/1) |
| 1991-02-25 (≤) | Ian Wachtmeister (Karlsson biträdande) | `i-SfnrsjEZBg9vdQjkU5VSZ2` | utsedd (formellt stämmoval ej dokumenterat) | – | [DN 1991-02-26 s.11](https://arkivet.dn.se/tidning/1991-02-26/56/11) |
| 1994-04-09 | Harriet Colliander | `i-9YGU9DsvbhLihhVNnvsKND` | vald (stämma) | Västerås | [DN 1994-04-10 s.7](https://arkivet.dn.se/tidning/1994-04-10/11175-96/7) |
| 1994-06-05 | Vivianne Franzén | `i-5kCq5AaWoBgtDWjyW8fFRC` | vald men ogiltigförklarad av tingsrätten (omstridd) | Västerås | [DN 1994-06-06 s.6](https://arkivet.dn.se/tidning/1994-06-06/11175-150/6) |
| 1994-07-13 (≤) | Harriet Colliander förklaras ”fortfarande den lagliga partiledaren” | `i-9YGU9DsvbhLihhVNnvsKND` | omstridd/parallell | – | [DN 1994-07-14 s.7](https://arkivet.dn.se/tidning/1994-07-14/11175-187/7) |
| 1994-07-28 (≤) | Gunilla Aastrup Persson (”utropat sig själv till ny ledare”; i efterhand kallad tillförordnad) | – | **tf**/självutropad | – | [DN 1994-07-29 s.10](https://arkivet.dn.se/tidning/1994-07-29/11175-202/10) |
| 1994-08-09 | Vivianne Franzén ”partiledare för en enda dag” | `i-5kCq5AaWoBgtDWjyW8fFRC` | omstridd | – | [DN 1994-08-10 s.9](https://arkivet.dn.se/tidning/1994-08-10/11175-214/9) |
| 1994-08-20 | Vivianne Franzén | `i-5kCq5AaWoBgtDWjyW8fFRC` | vald (extrastämma) | Linköping | [DN 1994-08-21 s.1](https://arkivet.dn.se/tidning/1994-08-21/11175-225/1) (även s.9) |
| 1997-01-18 | Bengt G Andersson (Franzén avsatt; 32–30 vid ”kaotisk extrastämma”) | – | vald | ej angiven | [DN 1997-01-19 s.15](https://arkivet.dn.se/tidning/1997-01-19/11184-17/15) |
| 1997-05-25 | John Bouvin (efter maj 1997: ingen succession funnen i DN trots att DN 1999 kallar honom ”före detta ordförande”) | `i-XAZuDYpjMWVDmo4L97UiJw` | vald | ej angiven | [DN 1997-05-26 s.10](https://arkivet.dn.se/tidning/1997-05-26/11184-139/10) |

## Anmärkningar

- **Interimsledare utan formellt val (tf) funna i DN:** Gustav Möller (S, 1946),
  tremannapresidiet Gafvelin/Enlund/Svensson (KD, 1972–73), Karin Söder (C,
  1985–86), Schörling & Roxbergh (MP, 1988), Gunilla Aastrup Persson (NyD, 1994,
  självutropad), Ulla Hoffmann med Ingrid Burman (V, 2003–04), Mattias Karlsson
  (SD, 2014–15), Johan Pehrson (L, 2022). **Moderaterna är det enda partiet helt
  utan DN-belagd interimsledare.**
- **Ej funna i DN:** SD:s första ledning 1988–89, Klarströms val ~1989, SD:s
  ledarskifte 1995 (Jansson), NyD:s eventuella succession efter Bouvin 1997
  (party-leaders.json anger Per Anders Gustavsson 1998–1999 och Ulf Eriksson
  1999–2000 — ej DN-belagt), Linderots formella val (V, ~1929), Eva Goës val
  (MP, ~1986).